### PR TITLE
Make sure values are numbers before formatting them

### DIFF
--- a/src/Components/CollectionPage/CollectionBuildingTable/Columns.tsx
+++ b/src/Components/CollectionPage/CollectionBuildingTable/Columns.tsx
@@ -21,11 +21,10 @@ const getColumnHeader = (apiKey: apiKeys) => {
 };
 
 const round = (value: number) => {
-  if (typeof value === "number") {
-    return value.toFixed(2);
-  } else {
+  if (typeof value !== "number") {
     return value;
   }
+  return value.toFixed(2);
 };
 
 const showYesNo = (value: boolean) => {
@@ -216,7 +215,7 @@ export const columns = [
       }),
       columnHelper.accessor("hpd_comp_apts_pct", {
         header: getColumnHeader("hpd_comp_apts_pct"),
-        cell: (info) => formatPercent(info.getValue()), //((info.getValue() as number) * 100).toFixed(2) + "%",
+        cell: (info) => formatPercent(info.getValue()),
         meta: {
           filterVariant: "range",
         },

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -13,6 +13,9 @@ export function splitBBL(bbl: string) {
 }
 
 export function formatMoney(amount: number): string {
+  if (typeof amount !== "number") {
+    return amount;
+  }
   const formatmoney = new Intl.NumberFormat("en", {
     style: "currency",
     currency: "USD",
@@ -23,10 +26,16 @@ export function formatMoney(amount: number): string {
 }
 
 export const formatPercent = (value: number) => {
+  if (typeof value !== "number") {
+    return value;
+  }
   return value.toFixed(0) + "%";
 };
 
 export const formatNumber = (value: number) => {
+  if (typeof value !== "number") {
+    return value;
+  }
   return new Intl.NumberFormat("en").format(value);
 };
 


### PR DESCRIPTION
Check if values are numbers before formatting. 

Pro is that this will not crash the site on null values.

Con is that this will not do any formatting on strings, which technically we could convert into numbers. I think this is better though, because it will help us catch string values from the API that should be numbers.