### PR TITLE
disable collection buildings table overflow-scroll-x

### DIFF
--- a/src/Components/Table/style.scss
+++ b/src/Components/Table/style.scss
@@ -1,7 +1,7 @@
 @import "../../colors.scss";
 .table-container {
   border: 1px solid lightgray;
-  overflow-x: scroll;
+  // overflow-x: scroll;
   width: 100%;
   position: relative;
 }


### PR DESCRIPTION
Had some issues with the horizontal scroll bar not being easily accessible, so decided to temporarily revert back to having the page be wide enough for the table (disabling the `overflow-scroll: x`)