### PR TITLE
Format emergency complaints per unit as percent

### DIFF
--- a/src/Components/Collection/BuildingTableColumns.tsx
+++ b/src/Components/Collection/BuildingTableColumns.tsx
@@ -201,7 +201,7 @@ export const columns = [
       }),
       columnHelper.accessor("hpd_comp_emerg_total_per_unit", {
         header: getColumnHeader("hpd_comp_emerg_total_per_unit"),
-        cell: (info) => round(info.getValue()),
+        cell: (info) => formatPercent(info.getValue()),
         filterFn: "inNumberRange",
         meta: {
           filterVariant: "range",

--- a/src/Components/Collection/CollectionSummaryTable/CollectionSummaryTable.tsx
+++ b/src/Components/Collection/CollectionSummaryTable/CollectionSummaryTable.tsx
@@ -3,6 +3,7 @@ import { CollectionInfo } from "../../../types/APIDataTypes";
 import { DetailTable } from "../../DetailTable/DetailTable";
 import { DetailTableRow } from "../../DetailTable/DetailTableRow";
 import "./style.scss";
+import { formatPercent } from "../../../util/helpers";
 
 type CollectionSummaryTableProps = {
   data: CollectionInfo;
@@ -30,7 +31,11 @@ export const CollectionSummaryTable: React.FC<CollectionSummaryTableProps> = ({
   data,
 }) => {
   const rows = keys.map((key) => {
-    return <DetailTableRow key={key} apiKey={key} value={data[key]} />;
+    let value = data[key];
+    if (key === "hpd_comp_emerg_total_per_unit" && typeof value === "number") {
+      value = formatPercent(value);
+    }
+    return <DetailTableRow key={key} apiKey={key} value={value} />;
   });
 
   return <DetailTable className="collection-summary-table">{rows}</DetailTable>;

--- a/src/Components/Pages/Buildings/Tables/BuildingHPDComplaints.tsx
+++ b/src/Components/Pages/Buildings/Tables/BuildingHPDComplaints.tsx
@@ -2,6 +2,7 @@ import { HTMLAttributes } from "react";
 import { BuildingInfo } from "../../../../types/APIDataTypes";
 import { DetailTable } from "../../../DetailTable/DetailTable";
 import { DetailTableRow } from "../../../DetailTable/DetailTableRow";
+import { formatPercent } from "../../../../util/helpers";
 
 interface BuildingHPDComplaintsTable extends HTMLAttributes<HTMLDListElement> {
   data: BuildingInfo;
@@ -18,7 +19,7 @@ export const BuildingHPDComplaintsTable: React.FC<
       />
       <DetailTableRow
         apiKey={"hpd_comp_emerg_total_per_unit"}
-        value={data["hpd_comp_emerg_total_per_unit"]}
+        value={formatPercent(data["hpd_comp_emerg_total_per_unit"])}
       />
       <DetailTableRow apiKey={"hpd_comp_apts"} value={data["hpd_comp_apts"]} />
       <DetailTableRow

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -117,7 +117,7 @@ export const INDICATOR_STRINGS: Partial<{ [key in apiKeys]: indicatorObj }> = {
     short_name: "Emergency complaints per unit, last 12 mo.",
     description:
       "Number of HPD complaints of emergency class received in the last 12 months, divided by the number of units. Read more on HPD Complaints.",
-    format: "round",
+    format: "percent",
   },
   hpd_comp_heat: {
     name: "HPD complaints for heat/hot water, last 12 mo.",


### PR DESCRIPTION
https://app.shortcut.com/justfixnyc/story/14846/of-units-with-complaints-needs-to-be-percent-formatted