### PR TITLE
update copy for download buttons and prevent flicker

### DIFF
--- a/src/Components/CSVDownload/CSVDownload.tsx
+++ b/src/Components/CSVDownload/CSVDownload.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Icon } from "@justfixnyc/component-library";
+import { Icon, Link } from "@justfixnyc/component-library";
 import "./styles.scss";
 import { BuildingInfo, CollectionInfo } from "../../types/APIDataTypes";
 import { INDICATOR_STRINGS, apiKeys, slugify } from "../../util/helpers";
@@ -59,7 +59,7 @@ export const generateMultiBuildingCSV = (data: CollectionInfo) => {
 };
 
 type DownloadProps = {
-  csvData: string[][];
+  csvData: string[][] | undefined;
   nameForFile: string;
   labelText: string;
 };
@@ -73,7 +73,7 @@ export const DownloadCSV: React.FC<DownloadProps> = ({
 
   const today = new Date(Date.now()).toISOString().slice(0, 10);
 
-  return (
+  return csvData ? (
     <CSVDownloader
       type={Type.Link}
       className="jfcl-link"
@@ -87,27 +87,32 @@ export const DownloadCSV: React.FC<DownloadProps> = ({
       <Icon icon="download" className="" />
       {labelText}
     </CSVDownloader>
+  ) : (
+    <Link className="disabled">
+      <Icon icon="download" className="" />
+      {labelText}
+    </Link>
   );
 };
 
 export const DownloadBuildingCSV: React.FC<{
-  data: BuildingInfo;
+  data: BuildingInfo | undefined;
   labelText: string;
 }> = ({ data, labelText }) => (
   <DownloadCSV
-    nameForFile={slugify(data.address)}
-    csvData={generateBuildingCSV(data)}
+    nameForFile={data ? slugify(data.address) : ""}
+    csvData={data && generateBuildingCSV(data)}
     labelText={labelText}
   />
 );
 
 export const DownloadMultiBuildingCSV: React.FC<{
-  data: CollectionInfo;
+  data: CollectionInfo | undefined;
   labelText: string;
 }> = ({ data, labelText }) => (
   <DownloadCSV
-    nameForFile={data.collection_slug}
-    csvData={generateMultiBuildingCSV(data)}
+    nameForFile={data ? data.collection_slug : ""}
+    csvData={data && generateMultiBuildingCSV(data)}
     labelText={labelText}
   />
 );

--- a/src/Components/CSVDownload/styles.scss
+++ b/src/Components/CSVDownload/styles.scss
@@ -1,6 +1,13 @@
+@import "../../colors.scss";
+
 .jfcl-link {
   cursor: pointer;
   svg {
     margin-right: 0.625rem; // 10px
+  }
+  &.disabled {
+    pointer-events: none;
+    cursor: default;
+    color: $GREY_600;
   }
 }

--- a/src/Components/Pages/Buildings/BuildingInfo.tsx
+++ b/src/Components/Pages/Buildings/BuildingInfo.tsx
@@ -59,12 +59,10 @@ export const BuildingInfo: React.FC<BuildingInfoProps> = ({ bbl }) => {
           ]}
         />
         <div className="top-bar-actions">
-          {!!buildingInfo && (
-            <DownloadBuildingCSV
-              data={buildingInfo}
-              labelText="Download building data"
-            />
-          )}
+          <DownloadBuildingCSV
+            data={buildingInfo}
+            labelText="Download building data"
+          />
         </div>
       </div>
       {buildingInfoIsLoading && <div>loading...</div>}

--- a/src/Components/Pages/Buildings/NoBBL.tsx
+++ b/src/Components/Pages/Buildings/NoBBL.tsx
@@ -25,12 +25,7 @@ export const NoBBL: React.FC = () => {
       <div className="top-bar">
         <PageTitle>Buildings</PageTitle>
         <div className="top-bar-actions">
-          {!!data && (
-            <DownloadMultiBuildingCSV
-              data={data}
-              labelText="Download all"
-            />
-          )}
+          <DownloadMultiBuildingCSV data={data} labelText="Download all" />
         </div>
       </div>
 

--- a/src/Components/Pages/Landlords/LandlordInfo.tsx
+++ b/src/Components/Pages/Landlords/LandlordInfo.tsx
@@ -29,12 +29,10 @@ export const LandlordInfo: React.FC<LandlordInfoProps> = ({ landlord }) => {
               ]}
             />
             <div className="top-bar-actions">
-              {!!data && (
-                <DownloadMultiBuildingCSV
-                  data={data}
-                  labelText="Download landlord data"
-                />
-              )}
+              <DownloadMultiBuildingCSV
+                data={data}
+                labelText="Download landlord data"
+              />
             </div>
           </div>
           <div className="layout-two-col">

--- a/src/Components/Pages/Lenders/LenderInfo.tsx
+++ b/src/Components/Pages/Lenders/LenderInfo.tsx
@@ -29,12 +29,10 @@ export const LenderInfo: React.FC<LenderInfoProps> = ({ lender }) => {
               ]}
             />
             <div className="top-bar-actions">
-              {!!data && (
-                <DownloadMultiBuildingCSV
-                  data={data}
-                  labelText={`Download ${data.collection_name} data`}
-                />
-              )}
+              <DownloadMultiBuildingCSV
+                data={data}
+                labelText={`Download ${data.collection_name} data`}
+              />
             </div>
           </div>
           <div className="layout-two-col">


### PR DESCRIPTION
In addition to copy updates, I removed some redundant conditional for waiting on data, and on the all buildings page the download button was flickering on so now while waiting for the data to download it appears as a disabled link/button. 

[sc-14954]