### PR TITLE
restrict all-time evictions charts to >=2017

### DIFF
--- a/src/Components/BarChart/BarChart.tsx
+++ b/src/Components/BarChart/BarChart.tsx
@@ -45,6 +45,7 @@ export type BarChartProps = {
   className?: string;
   stacked?: boolean;
   timeUnit?: IndicatorsTimeSpan;
+  xAxisStartDate?: Date;
 };
 
 const getTooltipDate = (value: string, timeUnit: IndicatorsTimeSpan) => {
@@ -79,6 +80,7 @@ export const BarChart: React.FC<BarChartProps> = ({
   stacked,
   yAxisTitle,
   timeUnit = "month",
+  xAxisStartDate,
   className,
 }) => {
   const [timespan, setTimespan] = useState<"two-years" | "all-time">(
@@ -167,7 +169,7 @@ export const BarChart: React.FC<BarChartProps> = ({
       x: {
         stacked: stacked,
         type: "time",
-        min: timespan === "two-years" ? twoYearsAgo : null,
+        min: timespan === "two-years" ? twoYearsAgo : xAxisStartDate || null,
         autoSkip: false,
         time: {
           unit: timeUnit,

--- a/src/Components/BarChart/Evictions.tsx
+++ b/src/Components/BarChart/Evictions.tsx
@@ -111,6 +111,7 @@ export const EvictionsChart: React.FC<EvictionsChartProps> = ({
       lastSaleDate={lastSaleDate}
       timeUnit="year"
       className={className}
+      xAxisStartDate={new Date('2017-01-01')}
     />
   );
 };


### PR DESCRIPTION
All our other charts go back to 2010, but we only have eviction data back to 2016/2017 (filings, executions) so we need to stop this chart here. For this I've added a prop to change all-time period start date in charts.
not strictly necessary, but I've also updated the database for the period as well. 

https://github.com/JustFixNYC/who-owns-what/pull/962

[sc-15406]