### PR TITLE
turn off dropdown option filtering

### DIFF
--- a/src/Components/AlgoliaSearch/AlgoliaSearch.tsx
+++ b/src/Components/AlgoliaSearch/AlgoliaSearch.tsx
@@ -85,6 +85,7 @@ const CustomSearchBox: React.FC<CustomSearchBoxProps> = ({
       // @ts-expect-error We need to update the JFCL options props to allow undefined
       options={selectOptions}
       noOptionsMessage={() => noOptionsMessage}
+      filterOption={null}
       placeholder={placeholder}
       className={classNames("algolia-search", className)}
     />


### PR DESCRIPTION
For the Good Cause Evcition screener we got user feedback that the address search was acting buggy. It turns out that the reac-select component we use for the dropdown does its own filtering of the options based on input (https://github.com/JustFixNYC/gce-screener/pull/13), but when using Geosearch or Algolia those are handling the filtering of options and they produce better results. For example, putting something like `8th ave` would cause react-select to remove results without the `th` whereas the API results include them.
