### PR TITLE
fix table filter/sort for district number strings

### DIFF
--- a/src/Components/BuildingTable/BuildingTableColumns.tsx
+++ b/src/Components/BuildingTable/BuildingTableColumns.tsx
@@ -566,7 +566,7 @@ export const columns = [
         id: "coun_dist",
         header: getColumnHeader("coun_dist"),
         sortUndefined: "last",
-        filterFn: "includesString",
+        filterFn: "equalsString",
         meta: {
           inputWidth: "1.5rem",
           filterVariant: "select",
@@ -576,7 +576,7 @@ export const columns = [
         id: "assem_dist",
         header: getColumnHeader("assem_dist"),
         sortUndefined: "last",
-        filterFn: "includesString",
+        filterFn: "equalsString",
         meta: {
           inputWidth: "1.5rem",
           filterVariant: "select",
@@ -586,7 +586,7 @@ export const columns = [
         id: "stsen_dist",
         header: getColumnHeader("stsen_dist"),
         sortUndefined: "last",
-        filterFn: "includesString",
+        filterFn: "equalsString",
         meta: {
           inputWidth: "1.5rem",
           filterVariant: "select",
@@ -596,7 +596,7 @@ export const columns = [
         id: "cong_dist",
         header: getColumnHeader("cong_dist"),
         sortUndefined: "last",
-        filterFn: "includesString",
+        filterFn: "equalsString",
         meta: {
           inputWidth: "1.5rem",
           filterVariant: "select",

--- a/src/Components/Table/Table.tsx
+++ b/src/Components/Table/Table.tsx
@@ -384,7 +384,7 @@ function Filter<T>({ column }: { column: Column<T, unknown> }) {
         ? []
         : Array.from(uniqeValues.keys())
             .filter((v) => v !== undefined)
-            .sort(),
+            .sort((a, b) => a - b),
     [uniqeValues, filterVariant]
   );
   return filterVariant === "range" ? (


### PR DESCRIPTION
All the political district values are stored as strings, and we were using the defaults so it was allowing partial matches for filtering (so `1` also matches `11` etc) and in the select dropdown they were sorting `10` before `2`. I just updated the filter and sort functions. 

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/92e2a043-2509-422d-b304-6489adb34d2d) | ![image](https://github.com/user-attachments/assets/d3e123cc-a221-4ec0-ad5a-59aca077e677) |

[sc-15936]