### PR TITLE
make loan status last updated date dynamic

### DIFF
--- a/src/Components/LoanStatusTable/LoanStatusTable.tsx
+++ b/src/Components/LoanStatusTable/LoanStatusTable.tsx
@@ -130,6 +130,11 @@ export const LoanStatusTable: React.FC<LoanStatusTableProps> = ({
     setShowDesc(!showDesc);
   };
 
+  // NOTE: This "unhp" record in our database table
+  // "nycdb_k8s_loader.dataset_tracker" is updated manually, unlike other
+  // datasets updated as part of the k8s-loader job, so whenever we get a new
+  // set of data files from UNHP we need to go in an manually update the date
+  // (eg. via postico).
   const lastUpdated = lastUpdatedData?.find(
     (x) => x.dataset === "unhp",
   )?.last_updated;

--- a/src/Components/LoanStatusTable/LoanStatusTable.tsx
+++ b/src/Components/LoanStatusTable/LoanStatusTable.tsx
@@ -3,7 +3,11 @@ import classNames from "classnames";
 import { Icon } from "@justfixnyc/component-library";
 import { DetailTable } from "../DetailTable/DetailTable";
 import { formatDate, formatLastUpdatedDate } from "../../util/helpers";
-import { BuildingInfo, LoanAction } from "../../types/APIDataTypes";
+import {
+  BuildingInfo,
+  DatasetLastUpdatedData,
+  LoanAction,
+} from "../../types/APIDataTypes";
 import JFCLLinkExternal from "../JFCLLinkExternal";
 
 import "./LoanStatusTable.scss";
@@ -110,13 +114,13 @@ const LoanHistorySection: React.FC<BuildingInfo> = ({
 
 interface LoanStatusTableProps extends HTMLAttributes<HTMLDListElement> {
   data: BuildingInfo;
-  lastUpdated: string;
+  lastUpdatedData?: DatasetLastUpdatedData[];
 }
 
 // Adapted from DetailRowTable.tsx
 export const LoanStatusTable: React.FC<LoanStatusTableProps> = ({
   data,
-  lastUpdated,
+  lastUpdatedData,
   className,
   ...props
 }) => {
@@ -125,6 +129,10 @@ export const LoanStatusTable: React.FC<LoanStatusTableProps> = ({
   const handleRowClick = () => {
     setShowDesc(!showDesc);
   };
+
+  const lastUpdated = lastUpdatedData?.find(
+    (x) => x.dataset === "unhp",
+  )?.last_updated;
 
   return (
     <DetailTable
@@ -167,10 +175,11 @@ export const LoanStatusTable: React.FC<LoanStatusTableProps> = ({
                 })}
             </div>
           </div>
-
-          <span className="last-updated">
-            Data last updated {formatLastUpdatedDate(lastUpdated)}
-          </span>
+          {lastUpdated && (
+            <span className="last-updated">
+              Data last updated {formatLastUpdatedDate(lastUpdated)}
+            </span>
+          )}
         </dd>
       </div>
     </DetailTable>

--- a/src/Components/Pages/Buildings/BuildingInfo.tsx
+++ b/src/Components/Pages/Buildings/BuildingInfo.tsx
@@ -140,7 +140,10 @@ export const BuildingInfo: React.FC<BuildingInfoProps> = ({ bbl }) => {
               <p className="loan-status-description">
                 {loanDescription(buildingInfo)}
               </p>
-              <LoanStatusTable data={buildingInfo} lastUpdated="2025-01-01" />
+              <LoanStatusTable
+                data={buildingInfo}
+                lastUpdatedData={lastUpdatedData}
+              />
 
               <SectionHeader id="summary-stats" className="scroll-el">
                 Summary stats


### PR DESCRIPTION
Before this was hardcoded, but insteead we can use the same `"unhp"` "dataset" from the dataset tracker system we have for other datasets. This one we just manually added to the database, and update the date manually (eg. via postico) when we get a new set of data from UNHP. 